### PR TITLE
chore: add ci nodejs version 20, 22 and 24

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x, 20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
close #81 

## Link to ticket

* https://github.com/nemtus/symbol-sdk-openapi-generator-typescript-fetch/issues

## What you did

* What did you do with this pull?

## What you will not do

* What you will not do with this pull request? (If any. If not, "none" is OK) (If not, state when you will do it or create the issue will be remained.)

## What developers will be able to do (from the developer's perspective)

* What will developers be able to do? (If any. (If not, "none" is OK.) ## What developer will be able to do (from the developer's perspective)

## What will not be possible (from the developer's perspective)

* What will be impossible to do? (If available. If not, "None" is OK.) * What will be impossible to do? (If no, then "None" is OK.)

## Operation check

* What kind of operation checks were performed?　What are the results?

## Others

* Reference information for reviewers (describe any implementation concerns or cautions)

## Your Symbol address

* Input your address to get reward.

N00000000000000000000000000000000000000
