### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI Node.js
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/nemtus/symbol-sdk-openapi-generator-typescript-fetch/security/code-scanning/4](https://github.com/nemtus/symbol-sdk-openapi-generator-typescript-fetch/security/code-scanning/4)

To fix the problem, add a `permissions` block to the workflow to explicitly limit the permissions granted to the GITHUB_TOKEN. The best way to do this is to add the block at the root level of the workflow file, so it applies to all jobs unless overridden. Since the workflow only checks out code, installs dependencies, builds, tests, and does a dry-run publish, it does not require write access to repository contents. Therefore, the minimal required permission is `contents: read`. This change should be made at the top of the file, after the `name` and before the `on` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
