### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd-publish-to-npm.yml
+++ b/.github/workflows/cd-publish-to-npm.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CD Publish to npm
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/nemtus/symbol-sdk-openapi-generator-typescript-fetch/security/code-scanning/2](https://github.com/nemtus/symbol-sdk-openapi-generator-typescript-fetch/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/cd-publish-to-npm.yml`. This block should be placed at the root level (above `jobs:`) to apply to all jobs in the workflow, unless a job requires different permissions. For publishing to npm, the minimal required permission is usually `contents: read`, but if the workflow needs to create releases or modify repository contents, you may need to set `contents: write`. Since the workflow runs `npm publish` (which uses the NPM_TOKEN secret, not GITHUB_TOKEN), and does not appear to modify repository contents, `contents: read` is likely sufficient. Add the following block after the workflow name and before `on:`:

```yaml
permissions:
  contents: read
```

No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
