### PR TITLE
ci: cd openapi generate in ci/cd environment

### DIFF
--- a/.github/workflows/cd-publish-to-npm.yml
+++ b/.github/workflows/cd-publish-to-npm.yml
@@ -26,8 +26,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
       - run: java -version
+      - run: npm install @openapitools/openapi-generator-cli -g
+      - run: openapi-generator-cli version
       - run: npm install
-      - run: npx @openapitools/openapi-generator-cli version
       - run: npm run openapi:set:version
       - run: npm run openapi:generate
       - run: npm run build

--- a/.github/workflows/cd-publish-to-npm.yml
+++ b/.github/workflows/cd-publish-to-npm.yml
@@ -1,9 +1,10 @@
-permissions:
-  contents: read
 name: CD Publish to npm
 
 on:
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   publish-to-npm:
@@ -11,15 +12,23 @@ jobs:
 
     strategy:
       matrix:
+        java-version: [21]
         node-version: [22.x]
 
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'microsoft'
+          java-version: ${{ matrix.java-version }}
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
+      - run: java -version
       - run: npm install
+      - run: npm run openapi:set:version
+      - run: npm run openapi:generate
       - run: npm run build
       - run: npm run test
       - run: npm publish --access=public

--- a/.github/workflows/cd-publish-to-npm.yml
+++ b/.github/workflows/cd-publish-to-npm.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - uses: actions/setup-java@v4
         with:
           distribution: 'microsoft'
@@ -25,7 +27,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
-      - run: git submodule update --remote
+      - run: git submodule update --init --recursive --remote
       - run: |
           git fetch origin
           git switch main

--- a/.github/workflows/cd-publish-to-npm.yml
+++ b/.github/workflows/cd-publish-to-npm.yml
@@ -27,6 +27,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: java -version
       - run: npm install
+      - run: npx @openapitools/openapi-generator-cli version
       - run: npm run openapi:set:version
       - run: npm run openapi:generate
       - run: npm run build

--- a/.github/workflows/cd-publish-to-npm.yml
+++ b/.github/workflows/cd-publish-to-npm.yml
@@ -25,6 +25,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
+      - run: git submodule update --remote
+      - run: |
+          git fetch origin
+          git switch main
+          git pull --ff-only
+          npm install
+          npm run build
+        working-directory: ./symbol-openapi
       - run: java -version
       - run: npm install @openapitools/openapi-generator-cli -g
       - run: openapi-generator-cli version

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -1,11 +1,12 @@
-permissions:
-  contents: read
 name: CI Node.js
 
 on:
   pull_request:
   push:
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -14,15 +15,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        java-version: [17, 21]
         node-version: [14.x, 16.x, 18.x, 20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'microsoft'
+          java-version: ${{ matrix.java-version }}
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
+      - run: java -version
       - run: npm install
+      - run: npm run openapi:set:version
+      - run: npm run openapi:generate
       - run: npm run build
       - run: npm run test
       - name: Dry run publish check (main branch only)

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -29,8 +29,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
       - run: java -version
+      - run: npm install @openapitools/openapi-generator-cli -g
+      - run: openapi-generator-cli version
       - run: npm install
-      - run: npx @openapitools/openapi-generator-cli version
       - run: npm run openapi:set:version
       - run: npm run openapi:generate
       - run: npm run build

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -28,6 +28,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
+      - run: git submodule update --remote
+      - run: |
+          git fetch origin
+          git switch main
+          git pull --ff-only
+          npm install
+          npm run build
+        working-directory: ./symbol-openapi
       - run: java -version
       - run: npm install @openapitools/openapi-generator-cli -g
       - run: openapi-generator-cli version

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -30,6 +30,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: java -version
       - run: npm install
+      - run: npx @openapitools/openapi-generator-cli version
       - run: npm run openapi:set:version
       - run: npm run openapi:generate
       - run: npm run build

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - uses: actions/setup-java@v4
         with:
           distribution: 'microsoft'
@@ -28,7 +30,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
-      - run: git submodule update --remote
+      - run: git submodule update --init --recursive --remote
       - run: |
           git fetch origin
           git switch main


### PR DESCRIPTION
close #107 

## Link to ticket

* https://github.com/nemtus/symbol-sdk-openapi-generator-typescript-fetch/issues

## What you did

* What did you do with this pull?

## What you will not do

* What you will not do with this pull request? (If any. If not, "none" is OK) (If not, state when you will do it or create the issue will be remained.)

## What developers will be able to do (from the developer's perspective)

* What will developers be able to do? (If any. (If not, "none" is OK.) ## What developer will be able to do (from the developer's perspective)

## What will not be possible (from the developer's perspective)

* What will be impossible to do? (If available. If not, "None" is OK.) * What will be impossible to do? (If no, then "None" is OK.)

## Operation check

* What kind of operation checks were performed?　What are the results?

## Others

* Reference information for reviewers (describe any implementation concerns or cautions)

## Your Symbol address

* Input your address to get reward.

N00000000000000000000000000000000000000


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Java tooling to CI with a Java version matrix and explicit Java checks.
  * Integrated OpenAPI versioning, generation and generator verification into the CI flow before build.
  * Enabled and updated handling of git submodules in CI and added a submodule update step.
  * Repositioned workflow permissions and standardized repository content permissions.
  * Updated publish to use the built distribution directory with authentication via an environment secret.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->