### PR TITLE
fix: ci cd

### DIFF
--- a/.github/workflows/cd-publish-to-npm.yml
+++ b/.github/workflows/cd-publish-to-npm.yml
@@ -12,6 +12,7 @@ jobs:
 
     strategy:
       matrix:
+        java-version: [21]
         node-version: [22.x]
 
     steps:

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         java-version: [17, 21]
-        node-version: [14.x, 16.x, 18.x, 20.x, 22.x, 24.x]
+        node-version: [16.x, 18.x, 20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
close #115 

## Link to ticket

* https://github.com/nemtus/symbol-sdk-openapi-generator-typescript-fetch/issues

## What you did

* What did you do with this pull?

## What you will not do

* What you will not do with this pull request? (If any. If not, "none" is OK) (If not, state when you will do it or create the issue will be remained.)

## What developers will be able to do (from the developer's perspective)

* What will developers be able to do? (If any. (If not, "none" is OK.) ## What developer will be able to do (from the developer's perspective)

## What will not be possible (from the developer's perspective)

* What will be impossible to do? (If available. If not, "None" is OK.) * What will be impossible to do? (If no, then "None" is OK.)

## Operation check

* What kind of operation checks were performed?　What are the results?

## Others

* Reference information for reviewers (describe any implementation concerns or cautions)

## Your Symbol address

* Input your address to get reward.

N00000000000000000000000000000000000000


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Continuous Integration now runs on Node.js 16, 18, 20, 22, and 24; Node.js 14 is no longer included in CI. This ensures compatibility checks across current runtime versions.
  * The publish pipeline now provisions Java 21 for release tasks, aligning the workflow with a modern Java runtime.
  * No changes to application features or behavior; these updates affect build and release automation only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->