### PR TITLE
test(nodejs-typescript): bump TypeScript ^4.7.4 → ^5.9.2

### DIFF
--- a/tests/nodejs-typescript/package-lock.json
+++ b/tests/nodejs-typescript/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "ts-node": "^10.9.1",
-        "typescript": "^4.7.4",
+        "typescript": "^5.9.2",
         "vitest": "^4.1.8"
       }
     },
@@ -1343,9 +1343,9 @@
       "optional": true
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1353,7 +1353,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/tests/nodejs-typescript/package.json
+++ b/tests/nodejs-typescript/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "devDependencies": {
     "ts-node": "^10.9.1",
-    "typescript": "^4.7.4",
+    "typescript": "^5.9.2",
     "vitest": "^4.1.8"
   },
   "dependencies": {


### PR DESCRIPTION
## What

The `tests/nodejs-typescript` consumer suite was pinned to **TypeScript 4**
(resolved 4.9.5) while the root SDK targets **TS 5** (`^5.9.2`). This aligns it to
`^5.9.2` (resolves 5.9.3) so the suite validates that the published SDK consumes
cleanly under modern TypeScript.

Only the `typescript` entry changes in `tests/nodejs-typescript/package-lock.json`.
`npm test` (vitest) passes locally (2/2).

## Why

Part of the pre-release Dependabot cleanup. Supersedes the stale transitive
`vite` Dependabot PR for this suite (#138). Test-suite only; no runtime/published
artifact impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)