### PR TITLE
ci: run dry-run-publish in parallel with tests (needs: build)

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -215,7 +215,11 @@ jobs:
         working-directory: ./tests/browser-cdn
 
   dry-run-publish:
-    needs: [test-unit, test-nodejs-javascript, test-nodejs-typescript, test-browser-cdn]
+    # Only needs the build artifact — `npm pack` validates packaging, independent of
+    # test outcomes — so run it in parallel with the test jobs instead of after them.
+    # (Gating it behind the live-node suites added latency but no safety: those are
+    # continue-on-error, and packaging validity doesn't depend on any test result.)
+    needs: build
     # Run on every event (PRs, main pushes, manual) so the publishable ./dist artifact
     # is validated before merge, not only after. It only downloads the artifact and runs
     # `npm publish --dry-run` (no auth/secrets), so it is cheap and fork-safe.

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -222,7 +222,7 @@ jobs:
     needs: build
     # Run on every event (PRs, main pushes, manual) so the publishable ./dist artifact
     # is validated before merge, not only after. It only downloads the artifact and runs
-    # `npm publish --dry-run` (no auth/secrets), so it is cheap and fork-safe.
+    # `npm pack --dry-run` (no auth/secrets), so it is cheap and fork-safe.
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
## What

`dry-run-publish` depended on all four test jobs (`needs: [test-unit,
test-nodejs-javascript, test-nodejs-typescript, test-browser-cdn]`). Change it to
`needs: build`.

## Why

The job only downloads the build artifact and runs `npm pack --dry-run`, which
validates packaging **independent of any test outcome**. Gating it behind the test
jobs added wall-clock latency (it waited on the slowest suite, e.g. browser-cdn)
but **no safety**:
- the three live-node suites are `continue-on-error: true` (non-gating), so they
  never fail the workflow anyway;
- packaging validity doesn't depend on test results, and a broken build still skips
  the job (`needs: build`).

Now it runs alongside the test jobs, shortening the critical path. CD's real
`publish` job keeps `needs: [test-unit, ...]` — there the test gate is meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)