### PR TITLE
build: fix npm audit critical (shell-quote 1.8.3 -> 1.8.4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4542,9 +4542,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
   ],
   "author": "nemtus",
   "license": "MIT",
+  "overrides": {
+    "shell-quote": "^1.8.4"
+  },
   "bugs": {
     "url": "https://github.com/nemtus/symbol-sdk-openapi-generator-typescript-fetch/issues"
   },


### PR DESCRIPTION
## 概要

CI の `npm audit` ゲートが 3 件の critical 脆弱性で fail していたため修正します（PR #167 など、main 由来の全 PR が同じ原因で fail）。

## 原因

- `shell-quote@1.8.3` の critical advisory [GHSA-w7jw-789q-3m8p](https://github.com/advisories/GHSA-w7jw-789q-3m8p)
- 依存経路: `@openapitools/openapi-generator-cli` → `concurrently@9.2.1` → `shell-quote@1.8.3`（`concurrently` が `1.8.3` を固定指定）
- `build` / `lint` 両ジョブとも `npm ci` 前の `npm audit --package-lock-only` ゲートで exit 1。

## 対応

`package.json` に `overrides` を追加し、パッチ版 `shell-quote@^1.8.4` を強制。

```json
"overrides": {
  "shell-quote": "^1.8.4"
}
```

## 確認

- `npm audit` → `found 0 vulnerabilities`
- 解決ツリー: `concurrently@9.2.1 -> shell-quote@1.8.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)