### PR TITLE
ci: derive Playwright container tag from locked npm version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,11 +55,15 @@ updates:
           - patch
 
   # ---- test suite: tests/browser-cdn ----
-  # `@playwright/test` / `playwright` are coupled to the Playwright CONTAINER tag
-  # (mcr.microsoft.com/playwright:vX.Y.Z-noble in .github/workflows/ci-nodejs.yml).
-  # Dependabot cannot edit that image tag, so bumping the npm package alone breaks the
-  # browser-cdn job. Keep Playwright bumps MANUAL — bump package.json AND the container
-  # tag together (see tests/CLAUDE.md) — and ignore them here.
+  # `@playwright/test` / `playwright` are NOT ignored: ignoring them would also
+  # suppress Dependabot security-update PRs, so a Playwright vulnerability could land
+  # unnoticed. These npm packages are coupled to the Playwright CONTAINER tag
+  # (mcr.microsoft.com/playwright:vX.Y.Z-noble in
+  # .github/workflows/{ci-nodejs,cd-publish-to-npm}.yml), which Dependabot cannot edit
+  # directly. The `detect-playwright-version` job in both workflows derives that tag from
+  # the locked `playwright` version in tests/browser-cdn, so the container auto-syncs to
+  # whatever Dependabot bumps the npm package to (see tests/CLAUDE.md) — no manual tag
+  # edit, no version drift.
   - package-ecosystem: 'npm'
     directory: '/tests/browser-cdn'
     schedule:
@@ -72,9 +76,6 @@ updates:
         update-types:
           - minor
           - patch
-    ignore:
-      - dependency-name: '@playwright/test'
-      - dependency-name: 'playwright'
 
   # ---- github actions ----
   - package-ecosystem: 'github-actions'

--- a/.github/workflows/cd-publish-to-npm.yml
+++ b/.github/workflows/cd-publish-to-npm.yml
@@ -212,7 +212,11 @@ jobs:
           persist-credentials: false
       - id: pw
         run: |
-          version="$(node -p "require('./tests/browser-cdn/package-lock.json').packages['node_modules/playwright'].version")"
+          version="$(node -p "require('./tests/browser-cdn/package-lock.json').packages['node_modules/playwright']?.version ?? ''")"
+          if [ -z "${version}" ]; then
+            echo "::error::Could not read playwright version from tests/browser-cdn/package-lock.json (packages['node_modules/playwright'].version) — the lockfile path or structure may have changed." >&2
+            exit 1
+          fi
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
   test-browser-cdn:

--- a/.github/workflows/cd-publish-to-npm.yml
+++ b/.github/workflows/cd-publish-to-npm.yml
@@ -199,14 +199,31 @@ jobs:
       - run: npm test
         working-directory: ./tests/nodejs-typescript
 
+  # Derive the Playwright container tag from the locked `playwright` version in
+  # tests/browser-cdn so the image always matches the npm package — no manual tag
+  # bump when Dependabot updates Playwright (see .github/dependabot.yml).
+  detect-playwright-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.pw.outputs.version }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - id: pw
+        run: |
+          version="$(node -p "require('./tests/browser-cdn/package-lock.json').packages['node_modules/playwright'].version")"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
   test-browser-cdn:
-    needs: build
+    needs: [build, detect-playwright-version]
     runs-on: ubuntu-latest
     # Hits a live mainnet node; deterministic coverage is in test-unit, so don't
     # let external flakiness block publishing.
     continue-on-error: true
     container:
-      image: mcr.microsoft.com/playwright:v1.60.0-noble
+      # Auto-synced to the locked playwright version by detect-playwright-version.
+      image: mcr.microsoft.com/playwright:v${{ needs.detect-playwright-version.outputs.version }}-noble
       options: --user 1001
 
     strategy:

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -209,7 +209,11 @@ jobs:
           persist-credentials: false
       - id: pw
         run: |
-          version="$(node -p "require('./tests/browser-cdn/package-lock.json').packages['node_modules/playwright'].version")"
+          version="$(node -p "require('./tests/browser-cdn/package-lock.json').packages['node_modules/playwright']?.version ?? ''")"
+          if [ -z "${version}" ]; then
+            echo "::error::Could not read playwright version from tests/browser-cdn/package-lock.json (packages['node_modules/playwright'].version) — the lockfile path or structure may have changed." >&2
+            exit 1
+          fi
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
   test-browser-cdn:

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -196,14 +196,31 @@ jobs:
       - run: npm test
         working-directory: ./tests/nodejs-typescript
 
+  # Derive the Playwright container tag from the locked `playwright` version in
+  # tests/browser-cdn so the image always matches the npm package — no manual tag
+  # bump when Dependabot updates Playwright (see .github/dependabot.yml).
+  detect-playwright-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.pw.outputs.version }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - id: pw
+        run: |
+          version="$(node -p "require('./tests/browser-cdn/package-lock.json').packages['node_modules/playwright'].version")"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
   test-browser-cdn:
-    needs: build
+    needs: [build, detect-playwright-version]
     runs-on: ubuntu-latest
     # Hits a live mainnet node; deterministic coverage is in test-unit, so don't
     # let external flakiness gate CI.
     continue-on-error: true
     container:
-      image: mcr.microsoft.com/playwright:v1.60.0-noble
+      # Auto-synced to the locked playwright version by detect-playwright-version.
+      image: mcr.microsoft.com/playwright:v${{ needs.detect-playwright-version.outputs.version }}-noble
       options: --user 1001
 
     strategy:

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -23,8 +23,14 @@ Subprojects:
 - `nodejs-javascript/` — CommonJS consumer, vitest. Run: `npm ci && npm test`.
 - `nodejs-typescript/` — ESM/TypeScript consumer, vitest. Run: `npm ci && npm test`.
 - `browser-cdn/` — loads the CDN bundle in a real browser via Playwright. CI runs it
-  inside the `mcr.microsoft.com/playwright:<version>-noble` container; keep the
-  `@playwright/test` version in `package.json` in sync with that container tag.
+  inside the `mcr.microsoft.com/playwright:<version>-noble` container, whose tag MUST
+  match the `@playwright/test` / `playwright` version. That tag is **derived
+  automatically**: the `detect-playwright-version` job in
+  `.github/workflows/{ci-nodejs,cd-publish-to-npm}.yml` reads the locked `playwright`
+  version from `package-lock.json` and the container uses
+  `v${{ needs.detect-playwright-version.outputs.version }}-noble`. So a Dependabot
+  Playwright bump needs **no** manual container-tag edit — it just works. (Dependabot is
+  intentionally NOT set to ignore Playwright, so security-update PRs are not hidden.)
 
 Conventions:
 - Each project has a local `vitest.config.mts` so it does NOT inherit the root


### PR DESCRIPTION
## What

The `test-browser-cdn` job ran inside a hardcoded `mcr.microsoft.com/playwright:v1.60.0-noble` container in both `ci-nodejs.yml` and `cd-publish-to-npm.yml`. Bumping the `playwright` / `@playwright/test` npm package therefore required a manual, lockstep edit of that image tag — which is why Dependabot was configured to **ignore** Playwright entirely (manual-bump workaround).

This mirrors the final commit of nemtus/symbol-sdk-openapi-generator-typescript-axios#99.

## Changes

- **`ci-nodejs.yml` / `cd-publish-to-npm.yml`**: add a `detect-playwright-version` job that reads the locked `playwright` version from `tests/browser-cdn/package-lock.json` (`packages['node_modules/playwright'].version`) and exposes it as a job output. `test-browser-cdn` now `needs: [build, detect-playwright-version]` and uses `mcr.microsoft.com/playwright:v${{ needs.detect-playwright-version.outputs.version }}-noble`. The image auto-syncs to the pinned npm version — no manual tag edit, no drift.
- **`.github/dependabot.yml`**: stop ignoring `@playwright/test` / `playwright`. With auto-sync, manual bumps are no longer needed, and un-ignoring restores Playwright security-update PRs.
- **`tests/CLAUDE.md`**: document the automatic tag derivation.

## Verification

- `node -p` extraction returns `1.60.0` against the current lockfile.
- All three YAML files parse cleanly.
- No residual `v1.60.0-noble` hardcodes or manual-sync wording remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automatic Playwright version detection in CI/CD workflows to keep test containers and dependencies synchronized, eliminating the need for manual version updates.
  * Removed version restrictions from dependency management configuration, enabling automated security updates for Playwright packages.

* **Documentation**
  * Updated testing documentation to explain how automated version management keeps Playwright dependencies synchronized across the test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->